### PR TITLE
[#FORM-138] Stop ProcessFormEntryQueueTask on shutdown

### DIFF
--- a/api/src/main/java/org/openmrs/module/formentry/ProcessFormEntryQueueTask.java
+++ b/api/src/main/java/org/openmrs/module/formentry/ProcessFormEntryQueueTask.java
@@ -67,7 +67,7 @@ public class ProcessFormEntryQueueTask extends AbstractTask {
 	    try {
 	      Context.getSchedulerService().shutdownTask(task);
 	    } catch (SchedulerException e) {
-	      e.printStackTrace();
+	    	log.error(e);
 	    }
 	}
 }


### PR DESCRIPTION
fix for https://tickets.openmrs.org/browse/FORM-138 | Replaced e.printStackTrace with log.error()
